### PR TITLE
provider/aws: Make the type of a route53_record changeable

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -49,7 +49,6 @@ func resourceAwsRoute53Record() *schema.Resource {
 			"type": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validateRoute53RecordType,
 			},
 
@@ -81,7 +80,6 @@ func resourceAwsRoute53Record() *schema.Resource {
 			"set_identifier": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"alias": &schema.Schema{
@@ -223,13 +221,122 @@ func resourceAwsRoute53RecordUpdate(d *schema.ResourceData, meta interface{}) er
 	// Route 53 supports CREATE, DELETE, and UPSERT actions. We use UPSERT, and
 	// AWS dynamically determines if a record should be created or updated.
 	// Amazon Route 53 can update an existing resource record set only when all
-	// of the following values match: Name, Type
-	// (and SetIdentifier, which we don't use yet).
-	// See http://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets_Requests.html#change-rrsets-request-action
-	//
-	// Because we use UPSERT, for resouce update here we simply fall through to
-	// our resource create function.
-	return resourceAwsRoute53RecordCreate(d, meta)
+	// of the following values match: Name, Type and SetIdentifier
+	// See http://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html
+
+	if !d.HasChange("type") && !d.HasChange("set_identifier") {
+		// If neither type nor set_identifier changed we use UPSERT,
+		// for resouce update here we simply fall through to
+		// our resource create function.
+		return resourceAwsRoute53RecordCreate(d, meta)
+	}
+
+	// Otherwise we delete the existing record and create a new record within
+	// a transactional change
+	conn := meta.(*AWSClient).r53conn
+	zone := cleanZoneID(d.Get("zone_id").(string))
+
+	var err error
+	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(zone)})
+	if err != nil {
+		return err
+	}
+	if zoneRecord.HostedZone == nil {
+		return fmt.Errorf("[WARN] No Route53 Zone found for id (%s)", zone)
+	}
+
+	// Build the to be deleted record
+	en := expandRecordName(d.Get("name").(string), *zoneRecord.HostedZone.Name)
+	typeo, _ := d.GetChange("type")
+
+	oldRec := &route53.ResourceRecordSet{
+		Name: aws.String(en),
+		Type: aws.String(typeo.(string)),
+	}
+
+	if v, _ := d.GetChange("ttl"); v != nil {
+		oldRec.TTL = aws.Int64(int64(v.(int)))
+	}
+
+	// Resource records
+	if v, _ := d.GetChange("records"); v != nil {
+		recs := v.(*schema.Set).List()
+		oldRec.ResourceRecords = expandResourceRecords(recs, typeo.(string))
+	}
+
+	// Alias record
+	if v, _ := d.GetChange("alias"); v != nil {
+		aliases := v.(*schema.Set).List()
+		if len(aliases) == 1 {
+			alias := aliases[0].(map[string]interface{})
+			oldRec.AliasTarget = &route53.AliasTarget{
+				DNSName:              aws.String(alias["name"].(string)),
+				EvaluateTargetHealth: aws.Bool(alias["evaluate_target_health"].(bool)),
+				HostedZoneId:         aws.String(alias["zone_id"].(string)),
+			}
+		}
+	}
+
+	if v, _ := d.GetChange("set_identifier"); v.(string) != "" {
+		oldRec.SetIdentifier = aws.String(v.(string))
+	}
+
+	// Build the to be created record
+	rec, err := resourceAwsRoute53RecordBuildSet(d, *zoneRecord.HostedZone.Name)
+	if err != nil {
+		return err
+	}
+
+	// Delete the old and create the new records in a single batch. We abuse
+	// StateChangeConf for this to retry for us since Route53 sometimes returns
+	// errors about another operation happening at the same time.
+	changeBatch := &route53.ChangeBatch{
+		Comment: aws.String("Managed by Terraform"),
+		Changes: []*route53.Change{
+			&route53.Change{
+				Action:            aws.String("DELETE"),
+				ResourceRecordSet: oldRec,
+			},
+			&route53.Change{
+				Action:            aws.String("CREATE"),
+				ResourceRecordSet: rec,
+			},
+		},
+	}
+
+	req := &route53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(cleanZoneID(*zoneRecord.HostedZone.Id)),
+		ChangeBatch:  changeBatch,
+	}
+
+	log.Printf("[DEBUG] Updating resource records for zone: %s, name: %s\n\n%s",
+		zone, *rec.Name, req)
+
+	respRaw, err := changeRoute53RecordSet(conn, req)
+	if err != nil {
+		return errwrap.Wrapf("[ERR]: Error building changeset: {{err}}", err)
+	}
+
+	changeInfo := respRaw.(*route53.ChangeResourceRecordSetsOutput).ChangeInfo
+
+	// Generate an ID
+	vars := []string{
+		zone,
+		strings.ToLower(d.Get("name").(string)),
+		d.Get("type").(string),
+	}
+	if v, ok := d.GetOk("set_identifier"); ok {
+		vars = append(vars, v.(string))
+	}
+
+	d.SetId(strings.Join(vars, "_"))
+
+	err = waitForRoute53RecordSetToSync(conn, cleanChangeID(*changeInfo.Id))
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsRoute53RecordRead(d, meta)
 }
 
 func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Utilize the ChangeResourceRecordSets to change the type of a record by
deleting and recreating with a new type.

As change batches are considered transactional changes, Amazon Route 53
either makes all or none of the changes in the batch request ensuring the
update will never be partially applied.

Fixes https://github.com/hashicorp/terraform/issues/9732